### PR TITLE
[snomed] Reduce lock contention in IndexServerService

### DIFF
--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/index/IndexServerService.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/index/IndexServerService.java
@@ -120,7 +120,6 @@ public abstract class IndexServerService<E extends IIndexEntry> extends Abstract
 	protected static final Logger LOGGER = LoggerFactory.getLogger(IndexServerService.class);
 	
 	private final LoadingCache<IBranchPath, IndexBranchService> branchServices;
-	private final Object branchServicesLock = new Object();
 	private final IndexAccessUpdater updater;
 	private final AtomicBoolean disposed = new AtomicBoolean();
 	
@@ -221,9 +220,9 @@ public abstract class IndexServerService<E extends IIndexEntry> extends Abstract
 		checkState(!physicalPath.isMain(), "Physical path cannot be MAIN.");
 		
 		try {
+			final IndexBranchService baseBranchService = getBranchService(logicalPath.getParent());
 			
-			synchronized (branchServicesLock) {
-				final IndexBranchService baseBranchService = getBranchService(logicalPath.getParent());
+			synchronized (baseBranchService) {
 				baseBranchService.createIndexCommit(logicalPath, physicalPath);
 				inactiveClose(logicalPath, true);
 				getBranchService(logicalPath);
@@ -256,11 +255,14 @@ public abstract class IndexServerService<E extends IIndexEntry> extends Abstract
 		
 		try {
 
-			synchronized (branchServicesLock) {
-				final IndexBranchService branchService = branchServices.getIfPresent(branchPath);
-				if (branchService != null && (!branchService.isDirty() || force)) {
-					branchServices.invalidate(branchPath);
-					return true;
+			final IndexBranchService branchService = branchServices.getIfPresent(branchPath);
+			
+			if (branchService != null && (!branchService.isDirty() || force)) {
+				synchronized (branchService) {
+					if ((!branchService.isDirty() || force)) {
+						branchServices.invalidate(branchPath);
+						return true;
+					}
 				}
 			}
 
@@ -273,11 +275,9 @@ public abstract class IndexServerService<E extends IIndexEntry> extends Abstract
 	
 	@Override
 	public void dispose() {
-		synchronized (branchServicesLock) {
-			if (disposed.compareAndSet(false, true)) {
-				updater.close();
-				branchServices.invalidateAll();
-			}
+		if (disposed.compareAndSet(false, true)) {
+			updater.close();
+			branchServices.invalidateAll();
 		}
 	}
 
@@ -825,11 +825,7 @@ public abstract class IndexServerService<E extends IIndexEntry> extends Abstract
 		}
 		
 		try {
-			
-			synchronized (branchServicesLock) {
-				return branchServices.get(branchPath);
-			}
-			
+			return branchServices.get(branchPath);
 		} catch (final ExecutionException e) {
 			throw IndexException.wrap(e.getCause());
 		} catch (final UncheckedExecutionException e) {


### PR DESCRIPTION
It is still prohibited for two threads to simultaneously run:
- reopen on the same (parent) branch;
- reopen and inactiveClose on the same branch;
- inactiveClose on the same branch.

This PR fixes a lock contention issue in index services. The problematic `branchServicesLock` field has been replaced with an object lock of the current branch service based on the path. 
Applying this change will improve the performance of concurrent index read requests even if the system currently in the process of opening a new branch index service (previously incoming HTTP requests, index read requests had to wait until the completion of the index initialization process).
