### PR TITLE
[api] Reduce excessive getCodeSystem calls via IStorageRef

### DIFF
--- a/core/com.b2international.snowowl.api.impl/src/com/b2international/snowowl/api/impl/history/AbstractHistoryServiceImpl.java
+++ b/core/com.b2international.snowowl.api.impl/src/com/b2international/snowowl/api/impl/history/AbstractHistoryServiceImpl.java
@@ -108,7 +108,7 @@ public abstract class AbstractHistoryServiceImpl implements IHistoryService {
 
 		final InternalComponentRef internalComponentRef = ClassUtils.checkAndCast(componentRef, InternalComponentRef.class);
 		internalComponentRef.checkStorageExists();
-		final String repositoryUuid = internalComponentRef.getRepositoryUuid();
+		final String repositoryUuid = internalComponentRef.getRepositoryId();
 
 		if (!handledRepositoryUuid.equals(repositoryUuid)) {
 			throw new IllegalArgumentException(MessageFormat.format(

--- a/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/IStorageRef.java
+++ b/core/com.b2international.snowowl.core/src/com/b2international/snowowl/core/domain/IStorageRef.java
@@ -15,17 +15,18 @@
  */
 package com.b2international.snowowl.core.domain;
 
+import com.b2international.snowowl.core.events.Request;
+
 /**
- * Points to a versioned component storage space of a code system, on a particular branch. 
+ * Points to a versioned component storage space of a code system, on a particular branch.
+ * @deprecated - will be removed in 4.7, use {@link Request} API instead 
  */
 public interface IStorageRef {
 
 	/**
-	 * Returns the code system short name, eg. "{@code SNOMEDCT}"
-	 * 
-	 * @return the code system short name
+	 * @return the repository identifier
 	 */
-	String getShortName();
+	String getRepositoryId();
 
 	/**
 	 * Returns the branch path eg. "{@code MAIN/projectA/task1}".

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/domain/ComponentRef.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/domain/ComponentRef.java
@@ -15,27 +15,19 @@
  */
 package com.b2international.snowowl.datastore.server.domain;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.b2international.commons.ClassUtils;
 import com.b2international.snowowl.core.domain.IComponentRef;
-import com.b2international.snowowl.core.domain.IStorageRef;
+import com.b2international.snowowl.core.events.Request;
 
 /**
  * @since 1.0
+ * @deprecated - will be removed in 4.7, use {@link Request} API instead
  */
 public class ComponentRef extends StorageRef implements InternalComponentRef {
 
 	private final String componentId;
 
-	public ComponentRef(IStorageRef sourceRef, String newComponentId) {
-		this(checkNotNull(sourceRef, "sourceRef").getShortName(), sourceRef.getBranchPath(), newComponentId);
-		final InternalStorageRef ref = ClassUtils.checkAndCast(sourceRef, InternalStorageRef.class);
-		setBranch(ref.getBranch());
-	}
-
-	public ComponentRef(String codeSystem, String branchPath, String componentId) {
-		super(codeSystem, branchPath);
+	public ComponentRef(String repositoryId, String branchPath, String componentId) {
+		super(repositoryId, branchPath);
 		this.componentId = componentId;
 	}
 
@@ -47,7 +39,7 @@ public class ComponentRef extends StorageRef implements InternalComponentRef {
 	@Override
 	public final int compareTo(final IComponentRef other) {
 		int result = 0;
-		if (result == 0) { result = getShortName().compareTo(other.getShortName()); }
+		if (result == 0) { result = getRepositoryId().compareTo(other.getRepositoryId()); }
 		if (result == 0) { result = getBranchPath().compareTo(other.getBranchPath()); }
 		if (result == 0) { result = getComponentId().compareTo(other.getComponentId()); }
 		return result;
@@ -56,8 +48,8 @@ public class ComponentRef extends StorageRef implements InternalComponentRef {
 	@Override
 	public String toString() {
 		final StringBuilder builder = new StringBuilder();
-		builder.append("ComponentRef [getShortName()=");
-		builder.append(getShortName());
+		builder.append("ComponentRef [getRepositoryId()=");
+		builder.append(getRepositoryId());
 		builder.append(", getBranchPath()=");
 		builder.append(getBranchPath());
 		builder.append(", componentId=");

--- a/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/domain/InternalStorageRef.java
+++ b/core/com.b2international.snowowl.datastore.server/src/com/b2international/snowowl/datastore/server/domain/InternalStorageRef.java
@@ -19,22 +19,13 @@ import org.eclipse.emf.cdo.common.branch.CDOBranch;
 
 import com.b2international.snowowl.core.branch.Branch;
 import com.b2international.snowowl.core.domain.IStorageRef;
-import com.b2international.snowowl.datastore.ICodeSystem;
+import com.b2international.snowowl.core.events.Request;
 
 /**
  * @since 1.0
+ * @deprecated - will be removed in 4.7, use {@link Request} API instead
  */
 public interface InternalStorageRef extends IStorageRef {
-
-	/**
-	 * @return
-	 */
-	ICodeSystem getCodeSystem();
-
-	/**
-	 * @return
-	 */
-	String getRepositoryUuid();
 
 	/**
 	 * @return the Branch associated with the storage reference.

--- a/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedClassificationServiceImpl.java
+++ b/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedClassificationServiceImpl.java
@@ -73,6 +73,7 @@ import com.b2international.snowowl.snomed.api.impl.domain.classification.Classif
 import com.b2international.snowowl.snomed.api.impl.domain.classification.EquivalentConcept;
 import com.b2international.snowowl.snomed.core.domain.CharacteristicType;
 import com.b2international.snowowl.snomed.core.domain.ISnomedDescription;
+import com.b2international.snowowl.snomed.datastore.SnomedDatastoreActivator;
 import com.b2international.snowowl.snomed.datastore.SnomedTerminologyBrowser;
 import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptIndexEntry;
 import com.b2international.snowowl.snomed.reasoner.classification.AbstractResponse.Type;
@@ -483,7 +484,7 @@ public class SnomedClassificationServiceImpl implements ISnomedClassificationSer
 	}
 
 	private StorageRef createStorageRef(final String branchPath) {
-		final StorageRef storageRef = new StorageRef("SNOMEDCT", branchPath);
+		final StorageRef storageRef = new StorageRef(SnomedDatastoreActivator.REPOSITORY_UUID, branchPath);
 		storageRef.checkStorageExists();
 		return storageRef;
 	}

--- a/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedExportService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedExportService.java
@@ -43,6 +43,7 @@ import com.b2international.snowowl.snomed.api.exception.SnomedExportException;
 import com.b2international.snowowl.snomed.common.ContentSubType;
 import com.b2international.snowowl.snomed.core.domain.ISnomedExportConfiguration;
 import com.b2international.snowowl.snomed.core.domain.Rf2ReleaseType;
+import com.b2international.snowowl.snomed.datastore.SnomedDatastoreActivator;
 import com.b2international.snowowl.snomed.datastore.SnomedTerminologyBrowser;
 import com.b2international.snowowl.snomed.exporter.model.SnomedRf2ExportModel;
 import com.google.common.collect.ImmutableMap;
@@ -90,7 +91,7 @@ public class SnomedExportService implements ISnomedExportService {
 		checkNotNull(configuration, "Configuration was missing for the export operation.");
 		final ContentSubType contentSubType = convertType(configuration.getRf2ReleaseType());
 		
-		final StorageRef exportStorageRef = new StorageRef("SNOMEDCT", configuration.getBranchPath());
+		final StorageRef exportStorageRef = new StorageRef(SnomedDatastoreActivator.REPOSITORY_UUID, configuration.getBranchPath());
 		final IBranchPath exportBranch = exportStorageRef.getBranch().branchPath();
 		
 		final SnomedRf2ExportModel model = createExportModelWithAllRefSets(contentSubType, exportBranch);

--- a/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedRf2ImportService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedRf2ImportService.java
@@ -179,7 +179,7 @@ public class SnomedRf2ImportService implements ISnomedRf2ImportService {
 		checkNotNull(configuration, "SNOMED CT import configuration should be specified.");
 		ApiValidation.checkInput(configuration);
 		
-		final StorageRef importStorageRef = new StorageRef("SNOMEDCT", configuration.getBranchPath());
+		final StorageRef importStorageRef = new StorageRef(REPOSITORY_UUID, configuration.getBranchPath());
 		
 		// Check version and branch existence in case of DELTA RF2 import
 		// FULL AND SNAPSHOT can be import into empty databases

--- a/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedServiceHelper.java
+++ b/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/SnomedServiceHelper.java
@@ -11,13 +11,12 @@ import com.b2international.snowowl.core.domain.IComponentRef;
 import com.b2international.snowowl.datastore.server.domain.ComponentRef;
 import com.b2international.snowowl.snomed.api.impl.domain.ISnomedConceptMin;
 import com.b2international.snowowl.snomed.core.domain.ISnomedDescription;
+import com.b2international.snowowl.snomed.datastore.SnomedDatastoreActivator;
 
 public class SnomedServiceHelper {
 
-	public static final String SNOMEDCT = "SNOMEDCT";
-
 	protected static IComponentRef createComponentRef(final String branchPath, final String componentId) {
-		final ComponentRef conceptRef = new ComponentRef(SNOMEDCT, branchPath, componentId);
+		final ComponentRef conceptRef = new ComponentRef(SnomedDatastoreActivator.REPOSITORY_UUID, branchPath, componentId);
 		conceptRef.checkStorageExists();
 		return conceptRef;
 	}

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/AbstractSnomedRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/AbstractSnomedRestService.java
@@ -37,14 +37,14 @@ import com.b2international.snowowl.eventbus.IEventBus;
 public abstract class AbstractSnomedRestService extends AbstractRestService {
 
 	@Autowired
-	@Value("${codeSystemShortName}")
-	protected String codeSystemShortName;
+	@Value("${repositoryId}")
+	protected String repositoryId;
 	
 	@Autowired
 	protected IEventBus bus;
 
 	protected IComponentRef createComponentRef(final String branchPath, final String componentId) {
-		final ComponentRef conceptRef = new ComponentRef(codeSystemShortName, branchPath, componentId);
+		final ComponentRef conceptRef = new ComponentRef(repositoryId, branchPath, componentId);
 		conceptRef.checkStorageExists();
 		return conceptRef;
 	}

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedExportRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedExportRestService.java
@@ -101,7 +101,7 @@ public class SnomedExportRestService extends AbstractSnomedRestService {
 		final String transientEffectiveTime = configuration.getTransientEffectiveTime();
 		validateTransientEffectiveTime(transientEffectiveTime);
 
-		final StorageRef exportStorageRef = new StorageRef(codeSystemShortName, configuration.getBranchPath());
+		final StorageRef exportStorageRef = new StorageRef(repositoryId, configuration.getBranchPath());
 		
 		// Check version and branch existence
 		exportStorageRef.checkStorageExists();

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/browser/SnomedBrowserRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/browser/SnomedBrowserRestService.java
@@ -333,7 +333,7 @@ public class SnomedBrowserRestService extends AbstractSnomedRestService {
 			throw new BadRequestException(e.getMessage());
 		}
 		
-		final StorageRef ref = new StorageRef(codeSystemShortName, branchPath);
+		final StorageRef ref = new StorageRef(repositoryId, branchPath);
 		return browserService.getDescriptions(ref, query, extendedLocales, offset, limit);
 	}
 

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/service_configuration.properties
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/service_configuration.properties
@@ -7,4 +7,3 @@ api.license=API License
 api.licenseUrl=http://b2i.sg/
 
 repositoryId=snomedStore
-codeSystemShortName=SNOMEDCT


### PR DESCRIPTION
Code system lookups require an extra round-trip to the index on the `MAIN` branch to resolve; use the unique repository identifier instead for routing requests to terminology repositories. (The identifier is currently set to a fixed value in `service_configuration.properties`, not derived from path parameters or otherwise from any request.)
