### PR TITLE
MAINT-76: Fix deletion of released components

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/components/SnomedDescriptionApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/components/SnomedDescriptionApiTest.java
@@ -51,6 +51,10 @@ import org.junit.Test;
 
 import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.api.IBranchPath;
+import com.b2international.snowowl.core.domain.TransactionContext;
+import com.b2international.snowowl.core.events.bulk.BulkRequest;
+import com.b2international.snowowl.core.events.bulk.BulkRequestBuilder;
+import com.b2international.snowowl.core.exceptions.ConflictException;
 import com.b2international.snowowl.core.terminology.ComponentCategory;
 import com.b2international.snowowl.datastore.BranchPathUtils;
 import com.b2international.snowowl.eventbus.IEventBus;
@@ -88,6 +92,8 @@ import com.jayway.restassured.http.ContentType;
  * @since 2.0
  */
 public class SnomedDescriptionApiTest extends AbstractSnomedApiTest {
+
+	private static final String ROOT_DESCRIPTION_ID = "2913224013";
 
 	@Test
 	public void createDescriptionNonExistentBranch() {
@@ -709,4 +715,33 @@ public class SnomedDescriptionApiTest extends AbstractSnomedApiTest {
 			.and().assertThat().statusCode(200)
 			.and().body("total", equalTo(1));
 	}
+	
+	@Test(expected = ConflictException.class)
+	public void doNotDeleteReleasedDescriptions() {
+		
+		String descriptionId = createNewDescription(branchPath);
+		
+		getComponent(branchPath, SnomedComponentType.DESCRIPTION, ROOT_DESCRIPTION_ID)
+			.statusCode(200)
+			.body("released", equalTo(true));
+		
+		getComponent(branchPath, SnomedComponentType.DESCRIPTION, descriptionId)
+			.statusCode(200)
+			.body("released", equalTo(false));
+		
+		final BulkRequestBuilder<TransactionContext> bulk = BulkRequest.create();
+		
+		bulk.add(SnomedRequests.prepareDeleteDescription(descriptionId));
+		bulk.add(SnomedRequests.prepareDeleteDescription(ROOT_DESCRIPTION_ID));
+
+		SnomedRequests.prepareCommit()
+			.setBody(bulk)
+			.setCommitComment("Delete multiple descriptions")
+			.setUserId("test")
+			.build(SnomedDatastoreActivator.REPOSITORY_UUID, branchPath.getPath())
+			.execute(ApplicationContext.getServiceForClass(IEventBus.class))
+			.getSync();
+		
+	}
+	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlan.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlan.java
@@ -25,8 +25,8 @@ import java.util.TreeSet;
 import org.eclipse.emf.cdo.CDOObject;
 
 import com.b2international.snowowl.datastore.utils.ComponentUtils2;
-import com.b2international.snowowl.snomed.Description;
-import com.google.common.collect.Sets;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
 
 /**
  * A DTO about the projected outcome of a delete operation in SNOMED CT.
@@ -35,9 +35,6 @@ public class SnomedDeletionPlan {
 
 	private final List<String> rejectionReasons = new ArrayList<String>();
 	
-	//	deleting concepts that are member of description type refset may affect concept descriptions.
-	private Collection<Description> descriptionsToUpdate = Sets.newHashSet();
-
 	// keep deletedItems sorted by type for nicer display to the user
 	private final Set<CDOObject> deletedItems = new TreeSet<CDOObject>(ComponentUtils2.CDO_OBJECT_COMPARATOR);
 	
@@ -45,13 +42,14 @@ public class SnomedDeletionPlan {
 	public List<String> getRejectionReasons() {
 		return rejectionReasons;
 	}
+	
 	public void addRejectionReason(final String rejectionReason) {
 		rejectionReasons.add(rejectionReason);
 	}
 
 	/** @return true if the requested plan cannot be executed because a concept or a relationship cannot be deleted */
 	public boolean isRejected() {
-		return rejectionReasons.size() > 0 || isEmpty();
+		return rejectionReasons.size() > 0;
 	}
 
 	/** @return true if there are any concepts or relationships in the delete plan */
@@ -84,11 +82,8 @@ public class SnomedDeletionPlan {
 		deletedItems.addAll(items);
 	}
 	
-	public Collection<Description> getDirtyDescriptions() {
-		return Collections.unmodifiableCollection(descriptionsToUpdate);
-	}
-	
-	public void addDirtyDescription(Description... descriptions) {
-		descriptionsToUpdate.addAll(Sets.newHashSet(descriptions));
+	@Override
+	public String toString() {
+		return rejectionReasons.size() < 2 ? Iterables.getFirst(rejectionReasons, "") : Joiner.on(", ").join(rejectionReasons);
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
@@ -24,7 +24,7 @@ public final class SnomedDeletionPlanMessages {
 
 	public static final String COMPONENT_IS_RELEASED_MESSAGE = "The %s '%s' has been released, and cannot be deleted.";
 	
-	public static final String UNABLE_TO_DELETE_CONCEPT_MESSAGE = "Cannot delete concept: '%s'.";
+	public static final String UNABLE_TO_DELETE_CONCEPT_DUE_TO_RELEASED_INBOUND_RSHIP_MESSAGE = "Cannot delete concept: '%s' because it has a released inbound relationship: '%s'.";
 	
 	public static final String UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE = "Cannot delete concept: '%s' because it is used as a description type.";
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedDeletionPlanMessages.java
@@ -26,11 +26,11 @@ public final class SnomedDeletionPlanMessages {
 	
 	public static final String UNABLE_TO_DELETE_CONCEPT_MESSAGE = "Cannot delete concept: '%s'.";
 	
+	public static final String UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE = "Cannot delete concept: '%s' because it is used as a description type.";
+	
 	public static final String UNABLE_TO_DELETE_CONCEPT_DUE_TO_ISA_RSHIP_MESSAGE = "Concept '%s' would be deleted when the last active 'Is a' relationship is deleted.";
 	
 	public static final String UNABLE_TO_DELETE_RELATIONSHIP_MESSAGE = "Cannot relationship concept: '%s'.";
-	
-	public static final String UNABLE_TO_DELETE_ONLY_FSN_DESCRIPTION_MESSAGE = "Cannot delete a description if it is the only fully specified name of a concept.";
 	
 	public static final String UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE = "Cannot delete reference set: '%s'.";
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/SnomedEditingContext.java
@@ -966,66 +966,25 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 	@Override
 	public void delete(EObject object, boolean force) {
 		if (object instanceof Concept) {
-			delete((Concept) object, force);
+			tryDelete((Concept) object, force);
 		} else if (object instanceof Description) {
-			delete((Description) object, force);
+			tryDelete((Description) object, force);
 		} else if (object instanceof Relationship) {
-			delete((Relationship) object, force);
+			tryDelete((Relationship) object, force);
 		} else if (object instanceof SnomedRefSet) {
-			delete((SnomedRefSet) object, force);
+			tryDelete((SnomedRefSet) object, force);
 		} else if (object instanceof SnomedRefSetMember) {
-			delete((SnomedRefSetMember) object, force);
+			tryDelete((SnomedRefSetMember) object, force);
 		} else {
 			super.delete(object, force);
 		}
-	}
-	
-	private void delete(Concept concept, boolean force) {
-		
-		canDelete(concept, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-
-	private void delete(Description description, boolean force) {
-		
-		canDelete(description, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-
-	private void delete(Relationship relationship, boolean force) {
-		
-		canDelete(relationship, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-
-	private void delete(SnomedRefSet refSet, boolean force) {
-		
-		canDelete(refSet, force);
 		
 		if (deletionPlan.isRejected()) {
 			throw new ConflictException(deletionPlan.toString());
 		}
 	}
 	
-	private void delete(SnomedRefSetMember member, boolean force) {
-		
-		canDelete(member, force);
-		
-		if (deletionPlan.isRejected()) {
-			throw new ConflictException(deletionPlan.toString());
-		}
-	}
-	
-	private void canDelete(Concept concept, boolean force) {
+	private void tryDelete(Concept concept, boolean force) {
 		
 		// Check if concept is already released, and this is not a forced delete
 		if (concept.isReleased() && !force) {
@@ -1033,35 +992,32 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			return;
 		}
 		
-		// Also check inbound relationships, as these could have been released with different effective times
 		for (Relationship relationship : getInboundRelationships(concept.getId())) {
+			
 			if (relationship != null) {
 				
-				canDelete(relationship, force);
+				tryDelete(relationship, force);
 				
 				if (deletionPlan.isRejected()) {
 					deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_CONCEPT_MESSAGE, toString(concept)));
 					return;
 				}
+				
 			}
 		}
 		
-		/*
-		 * All other components below should become released when the concept is first released, which was handled 
-		 * above, so don't exit early via a rejection check.
-		 */
-		
 		for (Description description : concept.getDescriptions()) {
-			canDelete(description, force);
+			tryDelete(description, force);
 		}
 		
 		for (Relationship outboundRelationship : concept.getOutboundRelationships()) {
-			canDelete(outboundRelationship, force);
+			tryDelete(outboundRelationship, force);
 		}
 		
 		SnomedRefSet refSet = new SnomedRefSetLookupService().getComponent(concept.getId(), transaction);
+		
 		if (refSet != null) {
-			canDelete(refSet, force);
+			tryDelete(refSet, force);
 		}
 		
 		List<SnomedRefSetMember> referringMembers = refSetEditingContext.getReferringMembers(concept);
@@ -1072,12 +1028,12 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		if (isDescriptionType.isPresent()) {
 			
 			boolean hasRelatedDescriptions = SnomedRequests.prepareSearchDescription()
-				.setLimit(1)
+				.setLimit(0)
 				.filterByType(concept.getId())
 				.build(SnomedDatastoreActivator.REPOSITORY_UUID, getBranch())
 				.execute(ApplicationContext.getServiceForClass(IEventBus.class))
 				.getSync()
-				.getItems().size() > 0;
+				.getTotal() > 0;
 			
 			if (hasRelatedDescriptions) {
 				deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_DESCRIPTION_TYPE_CONCEPT_MESSAGE, toString(concept)));
@@ -1086,11 +1042,14 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			
 		}
 		
-		deletionPlan.markForDeletion(referringMembers);
+		for (SnomedRefSetMember member: referringMembers) {
+			tryDelete(member, force);
+		}
+		
 		deletionPlan.markForDeletion(concept);
 	}
 
-	private void canDelete(Description description, boolean force) {
+	private void tryDelete(Description description, boolean force) {
 			
 		// Check if description is already released, and this is not a forced delete
 		if (description.isReleased() && !force) {
@@ -1098,19 +1057,24 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 			return;
 		}
 		
-		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(description));
+		for (SnomedRefSetMember member : refSetEditingContext.getReferringMembers(description)) {
+			tryDelete(member, force);
+		}
+		
 		deletionPlan.markForDeletion(description);
 	}
 
-	private void canDelete(Relationship relationship, boolean force) {
+	private void tryDelete(Relationship relationship, boolean force) {
 		
-		// Check if description is already released, and this is not a forced delete
+		// Check if relationship is already released, and this is not a forced delete
 		if (relationship.isReleased() && !force) {
 			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "relationship", toString(relationship)));
 			return;
 		}
 		
-		deletionPlan.markForDeletion(refSetEditingContext.getReferringMembers(relationship));
+		for (SnomedRefSetMember member : refSetEditingContext.getReferringMembers(relationship)) {
+			tryDelete(member, force);
+		}
 		
 		if (relationship.getSource() != null) {
 			deletionPlan.markForDeletion(relationship);
@@ -1118,10 +1082,11 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		
 	}
 
-	private void canDelete(SnomedRefSet refSet, boolean force) {
+	private void tryDelete(SnomedRefSet refSet, boolean force) {
 		
 		for (SnomedRefSetMember member : refSetEditingContext.getMembers(refSet)) {
-			canDelete(member, force);
+			
+			tryDelete(member, force);
 			
 			if (deletionPlan.isRejected()) {
 				deletionPlan.addRejectionReason(String.format(UNABLE_TO_DELETE_REFERENCE_SET_MESSAGE, refSet.getIdentifierId()));
@@ -1133,7 +1098,7 @@ public class SnomedEditingContext extends BaseSnomedEditingContext {
 		deletionPlan.markForDeletion(refSet);
 	}
 	
-	private void canDelete(SnomedRefSetMember member, boolean force) {
+	private void tryDelete(SnomedRefSetMember member, boolean force) {
 			
 		if (member.isReleased() && !force) {
 			deletionPlan.addRejectionReason(String.format(COMPONENT_IS_RELEASED_MESSAGE, "member", member.getUuid()));

--- a/snomed/com.b2international.snowowl.snomed.reasoner.server/src/com/b2international/snowowl/snomed/reasoner/server/classification/EquivalentConceptMerger.java
+++ b/snomed/com.b2international.snowowl.snomed.reasoner.server/src/com/b2international/snowowl/snomed/reasoner/server/classification/EquivalentConceptMerger.java
@@ -32,6 +32,7 @@ import com.b2international.commons.options.OptionsBuilder;
 import com.b2international.snowowl.core.ApplicationContext;
 import com.b2international.snowowl.core.api.IBranchPath;
 import com.b2international.snowowl.core.api.SnowowlRuntimeException;
+import com.b2international.snowowl.core.exceptions.ConflictException;
 import com.b2international.snowowl.datastore.BranchPathUtils;
 import com.b2international.snowowl.datastore.utils.ComponentUtils2;
 import com.b2international.snowowl.eventbus.IEventBus;
@@ -39,7 +40,6 @@ import com.b2international.snowowl.snomed.Concept;
 import com.b2international.snowowl.snomed.Relationship;
 import com.b2international.snowowl.snomed.core.domain.SnomedRelationships;
 import com.b2international.snowowl.snomed.datastore.SnomedDatastoreActivator;
-import com.b2international.snowowl.snomed.datastore.SnomedDeletionPlan;
 import com.b2international.snowowl.snomed.datastore.SnomedEditingContext;
 import com.b2international.snowowl.snomed.datastore.SnomedInactivationPlan;
 import com.b2international.snowowl.snomed.datastore.SnomedInactivationPlan.InactivationReason;
@@ -58,7 +58,6 @@ import com.b2international.snowowl.snomed.snomedrefset.SnomedRegularRefSet;
 import com.b2international.snowowl.snomed.snomedrefset.SnomedSimpleMapRefSetMember;
 import com.b2international.snowowl.snomed.snomedrefset.SnomedStructuralRefSet;
 import com.google.common.base.Function;
-import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Iterables;
@@ -121,29 +120,26 @@ public class EquivalentConceptMerger {
 		
 		// iterate over the sorted concepts and switch to the equivalent using
 		// the resolved Map
-		final SnomedDeletionPlan deletionPlan = new SnomedDeletionPlan();
-		for (final Concept conceptToKeep : equivalentConcepts.keySet()) {
-			final Collection<Concept> conceptsToRemove = equivalentConcepts.get(conceptToKeep);
-			switchToEquivalentConcept(conceptToKeep, conceptsToRemove, inboundRelationshipMap);
-			removeOrDeactivate(conceptsToRemove, deletionPlan);
-		}
-		if (!deletionPlan.isEmpty()) {
-			if (!deletionPlan.isRejected()) {
-				this.editingContext.delete(deletionPlan);
-			} else {
-				throw new SnowowlRuntimeException(Joiner.on(",").join(deletionPlan.getRejectionReasons()));
+		try {
+			for (final Concept conceptToKeep : equivalentConcepts.keySet()) {
+				final Collection<Concept> conceptsToRemove = equivalentConcepts.get(conceptToKeep);
+				switchToEquivalentConcept(conceptToKeep, conceptsToRemove, inboundRelationshipMap);
+				removeOrDeactivate(conceptsToRemove);
 			}
+			
+		} catch (ConflictException e) {
+			throw new SnowowlRuntimeException(e);
 		}
 	}
 
-	private void removeOrDeactivate(Collection<Concept> conceptsToRemove, final SnomedDeletionPlan deletionPlan) {
+	private void removeOrDeactivate(Collection<Concept> conceptsToRemove) {
 		if (!Iterables.isEmpty(conceptsToRemove)) {
 			final SnomedInactivationPlan plan = new SnomedInactivationPlan(this.editingContext);
 			for (final Concept concept : conceptsToRemove) {
 				if (concept.isReleased()) {
 					this.editingContext.inactivateConcepts(plan, new NullProgressMonitor(), concept.cdoID());		
 				} else {
-					this.editingContext.canDelete(concept, deletionPlan, false);
+					this.editingContext.delete(concept, false);
 				}
 			}
 			plan.performInactivation(InactivationReason.RETIRED, null);


### PR DESCRIPTION
This pull request fixes the deletion of released components:
- always use one SnomedDeletionPlan per SnomedEditingContext
- allow deleting the last FSN of a concept
- simplified validation of description type concepts
- added unit tests for concepts, relationships and descriptions

https://jira.ihtsdotools.org/browse/MAINT-76