### PR TITLE
APDS-455: Add support to export fully specified names to tsv format

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/AbstractSnomedApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/AbstractSnomedApiTest.java
@@ -43,6 +43,9 @@ import com.jayway.restassured.response.Response;
 @BranchBase(Branch.MAIN_PATH)
 public abstract class AbstractSnomedApiTest {
 	
+	protected static final String CONTENT_TYPE_TXT_CSV = "text/csv";
+	protected static final String CONTENT_TYPE_UTF_8_JSON = "application/json; charset=UTF-8";
+	
 	private final class CustomTestWatcher extends TestWatcher {
 		@Override
 		protected void starting(Description description) {

--- a/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/classification/SnomedClassificationApiTest.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest.tests/src/com/b2international/snowowl/snomed/api/rest/classification/SnomedClassificationApiTest.java
@@ -112,7 +112,7 @@ public class SnomedClassificationApiTest extends AbstractSnomedApiTest {
 		return relationships.size();
 	}
 
-	//@Test
+	@Test
 	public void persistInferredRelationship() throws Exception {
 		String parentConceptId = createNewConcept(branchPath);
 		String targetConceptId = createNewConcept(branchPath);
@@ -176,7 +176,7 @@ public class SnomedClassificationApiTest extends AbstractSnomedApiTest {
 		assertEquals(Type.NOT_AVAILABLE, response.getType()); 
 	}
 
-	//@Test
+	@Test
 	public void persistRedundantRelationship() throws Exception {
 		String parentConceptId = createNewConcept(branchPath);
 		String childConceptId = createNewConcept(branchPath, parentConceptId);
@@ -213,7 +213,7 @@ public class SnomedClassificationApiTest extends AbstractSnomedApiTest {
 		assertEquals(1, getPersistedInferredRelationshipCount(branchPath, childConceptId));
 	}
 
-	//@Test
+	@Test
 	public void issue_SO_2152_testGroupRenumbering() throws Exception {
 		String conceptId = createNewConcept(branchPath);
 
@@ -256,7 +256,7 @@ public class SnomedClassificationApiTest extends AbstractSnomedApiTest {
 		assertTrue("No redundant relationships found in response.", redundantFound);
 	}
 	
-	//@Test
+	@Test
 	public void issue_APDS_327_testNoStatedRedundantRelationshipChanges() throws Exception {
 		
 		String conceptId = createNewConcept(branchPath);
@@ -313,7 +313,7 @@ public class SnomedClassificationApiTest extends AbstractSnomedApiTest {
 		}
 	}
 
-	//@Test
+	@Test
 	public void issue_SO_1830_testInferredEquivalentConceptParents() throws Exception {
 		String parentConceptId = createNewConcept(branchPath);
 		String childConceptId = createNewConcept(branchPath, parentConceptId);
@@ -386,7 +386,7 @@ public class SnomedClassificationApiTest extends AbstractSnomedApiTest {
 		Set<String> responseRows = Sets.newHashSet(Splitter.on('\n').split(responseString)).stream().filter(row -> !Strings.isNullOrEmpty(row)).collect(Collectors.toSet());
 		
 		Set<String> expectedRows = Sets.newHashSet(
-				String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s","changeNature", "sourceId", "sourceFsn", "typeId", "typeFsn", "destinationId", "destinationFsn", "destinationNegated", "characteristicTypeId", "group", "id", "unionGroup", "modifier"),
+				String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", "changeNature", "sourceId", "sourceFsn", "typeId", "typeFsn", "destinationId", "destinationFsn", "destinationNegated", "characteristicTypeId", "group", "id", "unionGroup", "modifier"),
 				String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s", "INFERRED", sourceConcept, "\"FSN of concept\"", "116680003", "\"Is a (attribute)\"", "138875005", "\"SNOMED CT Concept (SNOMED RT+CTV3)\"", "false", "900000000000011006", "", "", "", "EXISTENTIAL"));
 
 		assertEquals(responseRows, expectedRows);

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedCsvConcept.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedCsvConcept.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.api.rest.domain;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * Representation of a SnomedConcept for easier mapping to Csv format
+ */
+@JsonPropertyOrder({ "id", "fsn", "effectiveTime", "active", "moduleId", "definitionStatus"})
+public class SnomedCsvConcept {
+
+	private final String id;
+	private final String effectiveTime;
+	private final boolean active;
+	private final String moduleId;
+	private final String definitionStatus;
+	private final String fsn;
+
+	public SnomedCsvConcept(String id, String effectiveTime, boolean active, String moduleId, String definitionStatus, String fsn) {
+		this.id = id;
+		this.effectiveTime = effectiveTime;
+		this.active = active;
+		this.moduleId = moduleId;
+		this.definitionStatus = definitionStatus;
+		this.fsn = fsn;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getEffectiveTime() {
+		return effectiveTime;
+	}
+
+	public boolean isActive() {
+		return active;
+	}
+
+	public String getModuleId() {
+		return moduleId;
+	}
+
+	public String getDefinitionStatus() {
+		return definitionStatus;
+	}
+
+	public String getFsn() {
+		return fsn;
+	}
+
+}

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/util/CsvMessageConverter.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/util/CsvMessageConverter.java
@@ -2,9 +2,9 @@ package com.b2international.snowowl.snomed.api.rest.util;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
-import java.util.TimeZone;
+import java.util.List;
 
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
@@ -13,37 +13,29 @@ import org.springframework.http.converter.AbstractHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 
+import com.b2international.snowowl.core.date.DateFormats;
+import com.b2international.snowowl.core.date.EffectiveTimes;
 import com.b2international.snowowl.core.domain.CollectionResource;
 import com.b2international.snowowl.core.exceptions.NotImplementedException;
-import com.b2international.snowowl.snomed.api.rest.domain.CollectionResourceMixin;
-import com.b2international.snowowl.snomed.api.rest.domain.ISnomedComponentMixin;
-import com.b2international.snowowl.snomed.common.SnomedRf2Headers;
-import com.b2international.snowowl.snomed.core.domain.SnomedComponent;
+import com.b2international.snowowl.snomed.api.rest.domain.SnomedCsvConcept;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
-import com.google.common.collect.Maps;
 
 @SuppressWarnings("rawtypes")
 public class CsvMessageConverter extends AbstractHttpMessageConverter<CollectionResource> {
-	private static final String DEFINITION_STATUS = "definitionStatus";
-	private static final String ATTACHMENT = "attachment";
-	private static final String CONTENT_DISPOSITION = "Content-Disposition";
 	private static final MediaType MEDIA_TYPE = new MediaType("text", "csv", Charset.forName("utf-8"));
+	private static final String CONTENT_DISPOSITION = "Content-Disposition";
+	private static final String ATTACHMENT = "attachment";
 
 	private CsvMapper mapper;
-	private Map<Class<?>, CsvSchema> predefinedSchemas;
 
 	public CsvMessageConverter() {
 		super(MEDIA_TYPE);
 		this.mapper = initCsvMapper();
-		this.predefinedSchemas = initSchemas();
 	}
 
 	@Override
@@ -55,60 +47,65 @@ public class CsvMessageConverter extends AbstractHttpMessageConverter<Collection
 		final CsvMapper csvMapper = new CsvMapper();
 		csvMapper.registerModule(new GuavaModule());
 		csvMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
-		csvMapper.configure(Feature.IGNORE_UNKNOWN, true);
-		final ISO8601DateFormat df = new ISO8601DateFormat();
-		df.setTimeZone(TimeZone.getTimeZone("UTC"));
-		csvMapper.setDateFormat(df);
-		csvMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-		csvMapper.addMixIn(CollectionResource.class, CollectionResourceMixin.class);
-		csvMapper.addMixIn(SnomedComponent.class, ISnomedComponentMixin.class);
 		return csvMapper;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
 	protected void writeInternal(CollectionResource response, HttpOutputMessage output) throws IOException, HttpMessageNotWritableException {
-		final Collection<Object> items = response.getItems();
+		Collection<Object> items = response.getItems();
 		if (!items.isEmpty()) {
+			
 			output.getHeaders().setContentType(MEDIA_TYPE);
 			output.getHeaders().set(CONTENT_DISPOSITION, ATTACHMENT);
-
+			
 			final Class<?> clazz = items.iterator().next().getClass();
-			CsvSchema schema = predefinedSchemas.get(clazz);
-
-			if (schema == null) {
-				schema = mapper.schemaFor(clazz).withHeader().withColumnSeparator('\t');
-			}
+			CsvSchema schema = mapper.schemaFor(getClassForConversion(clazz)).withHeader().withColumnSeparator('\t');
+			
+			items = convert(items, clazz);
+			
 			ObjectWriter writer = mapper.writer(schema);
 			writer.writeValue(output.getBody(), items);
 		}
 	}
 
+	private Class<?> getClassForConversion(Class<?> clazz) {
+		if (clazz.isAssignableFrom(SnomedConcept.class)) {
+			return SnomedCsvConcept.class;
+		}
+		return clazz;
+	}
+
+	private Collection<Object> convert(Collection<Object> items, Class<?> clazz) { 
+		final List<Object> convertedItems = new ArrayList<>();
+
+		for (Object item : items) {
+			if (item instanceof SnomedConcept) {
+				SnomedConcept concept = (SnomedConcept) item;
+				convertedItems.add(convertConcept(concept));
+			} else {
+				convertedItems.add(item);
+			}
+		}
+		
+		return convertedItems;
+	}
+	
+	private SnomedCsvConcept convertConcept(SnomedConcept concept) {
+		
+		return new SnomedCsvConcept(
+				concept.getId(),
+				EffectiveTimes.format(concept.getEffectiveTime(), DateFormats.SHORT),
+				concept.isActive(),
+				concept.getModuleId(),
+				concept.getDefinitionStatus().name(),
+				concept.getFsn() != null ? concept.getFsn().getTerm() : "");
+	}
+	
 	@Override
 	protected CollectionResource readInternal(Class<? extends CollectionResource> arg0, HttpInputMessage arg1)
 			throws IOException, HttpMessageNotReadableException {
 		throw new NotImplementedException();
-	}
-
-	private Map<Class<?>, CsvSchema> initSchemas() {
-		final Map<Class<?>, CsvSchema> predefinedSchemas = Maps.newHashMap();
-		final CsvSchema snomedConceptCsvSchema = createSchemaForSnomedConcept();
-		predefinedSchemas.put(SnomedConcept.class, snomedConceptCsvSchema);
-		return predefinedSchemas;
-	}
-
-	private CsvSchema createSchemaForSnomedConcept() {
-		final CsvSchema csvSnomedConceptSchema = CsvSchema.builder()
-				.addColumn(SnomedRf2Headers.FIELD_ID)
-				.addColumn(SnomedRf2Headers.FIELD_EFFECTIVE_TIME)
-				.addBooleanColumn(SnomedRf2Headers.FIELD_ACTIVE)
-				.addColumn(SnomedRf2Headers.FIELD_MODULE_ID)
-				.addColumn(DEFINITION_STATUS)
-				.build()
-				.withHeader()
-				.withColumnSeparator('\t');
-		
-		return csvSnomedConceptSchema;
 	}
 
 }


### PR DESCRIPTION
- Added tests for concepts GET endpoint,
- Changed the test of concepts/Search POST endpoint
- Added test for relationship changes endpoint
- Modified CsvMessageConverter to support fsn-s on concept searches
- Added SnomedCsvConcept POJO class for easier Csv conversion
- Moved constants into AbstractSnomedApiTest class

https://jira.ihtsdotools.org/browse/APDS-455