### PR TITLE
MAINT-113: Support ECL evaluation on stated relationships

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedConceptRestService.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/SnomedConceptRestService.java
@@ -130,9 +130,13 @@ public class SnomedConceptRestService extends AbstractSnomedRestService {
 			@RequestParam(value="escg", required=false) 
 			final String escgFilter,
 			
-			@ApiParam(value="The ECL expression to match")
+			@ApiParam(value="The ECL expression to match in the inferred tree")
 			@RequestParam(value="ecl", required=false) 
 			final String eclFilter,
+			
+			@ApiParam(value="The ECL expression to match in the stated tree")
+			@RequestParam(value="statedEcl", required=false)
+			final String statedEclFilter,
 			
 			@ApiParam(value="A set of concept identifiers")
 			@RequestParam(value="conceptIds", required=false) 
@@ -164,6 +168,7 @@ public class SnomedConceptRestService extends AbstractSnomedRestService {
 				descriptionActiveFilter,
 				escgFilter,
 				eclFilter,
+				statedEclFilter,
 				conceptIds,
 				offset,
 				limit,
@@ -208,6 +213,7 @@ public class SnomedConceptRestService extends AbstractSnomedRestService {
 				body.getDescriptionActiveFilter(),
 				body.getEscgFilter(),
 				body.getEclFilter(),
+				body.getStatedEclFilter(),
 				body.getConceptIds(),
 				body.getOffset(),
 				body.getLimit(),
@@ -226,6 +232,7 @@ public class SnomedConceptRestService extends AbstractSnomedRestService {
 			final Boolean descriptionActiveFilter,
 			final String escgFilter,
 			final String eclFilter,
+			final String statedEclFilter,
 			final Set<String> conceptIds, 
 			final int offset,
 			final int limit,
@@ -261,6 +268,7 @@ public class SnomedConceptRestService extends AbstractSnomedRestService {
 					.filterByDescriptionActive(descriptionActiveFilter)
 					.filterByEscg(escgFilter)
 					.filterByEcl(eclFilter)
+					.filterByStatedEcl(statedEclFilter)
 					.filterByExtendedLocales(extendedLocales)
 					.setExpand(expand)
 					.setLocales(extendedLocales)

--- a/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedConceptRestSearch.java
+++ b/snomed/com.b2international.snowowl.snomed.api.rest/src/com/b2international/snowowl/snomed/api/rest/domain/SnomedConceptRestSearch.java
@@ -22,6 +22,7 @@ public class SnomedConceptRestSearch {
 	private String termFilter;
 	private String escgFilter;
 	private String eclFilter;
+	private String statedEclFilter;
 	private Set<String> conceptIds;
 	private String moduleFilter;
 	private String definitionStatusFilter;
@@ -53,6 +54,14 @@ public class SnomedConceptRestSearch {
 	
 	public void setEclFilter(String eclFilter) {
 		this.eclFilter = eclFilter;
+	}
+	
+	public String getStatedEclFilter() {
+		return statedEclFilter;
+	}
+	
+	public void setStatedEclFilter(String statedEclFilter) {
+		this.statedEclFilter = statedEclFilter;
 	}
 
 	public Set<String> getConceptIds() {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
@@ -26,6 +26,8 @@ import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedCom
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedComponentDocument.Fields.REFERRING_REFSETS;
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.ancestors;
 import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.parents;
+import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedAncestors;
+import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedParents;
 import static com.google.common.collect.Sets.newHashSet;
 
 import java.util.Collection;
@@ -34,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.util.PolymorphicDispatcher;
@@ -51,6 +54,7 @@ import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.core.exceptions.NotImplementedException;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcept;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
+import com.b2international.snowowl.snomed.core.tree.Trees;
 import com.b2international.snowowl.snomed.ecl.ecl.AncestorOf;
 import com.b2international.snowowl.snomed.ecl.ecl.AncestorOrSelfOf;
 import com.b2international.snowowl.snomed.ecl.ecl.AndExpressionConstraint;
@@ -89,12 +93,20 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	@Nullable
 	@JsonProperty
 	private String expression;
-
+	
+	@NotNull
+	@JsonProperty
+	private String expressionForm = Trees.INFERRED_FORM;
+	
 	SnomedEclEvaluationRequest() {
 	}
-
+	
 	void setExpression(String expression) {
 		this.expression = expression;
+	}
+	
+	void setExpressionForm(String expressionForm) {
+		this.expressionForm = expressionForm;
 	}
 
 	@Override
@@ -149,7 +161,9 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 					.build());
 		} else if (inner instanceof NestedExpression) {
 			final String focusConceptExpression = context.service(EclSerializer.class).serializeWithoutTerms(inner);
-			return EclExpression.of(focusConceptExpression)
+			final EclExpression eclExpression = EclExpression.of(focusConceptExpression);
+			eclExpression.setExpressionForm(expressionForm);
+			return eclExpression
 					.resolve(context)
 					.then(ids -> {
 						return Expressions.builder()
@@ -171,19 +185,20 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 		// <* should eval to * MINUS parents IN (ROOT_ID)
 		if (inner instanceof Any) {
 			return Promise.immediate(Expressions.builder()
-					.mustNot(parents(Collections.singleton(IComponent.ROOT_ID)))
+					.mustNot(addParentsExpressionBasedOnForm(Collections.singleton(IComponent.ROOT_ID)))
 					.build());
 		} else {
 			return evaluate(context, inner)
-					.thenWith(resolveIds(context, inner))
+					.thenWith(resolveIds(context, inner, expressionForm))
 					.then(new Function<Set<String>, Expression>() {
 						@Override
 						public Expression apply(Set<String> ids) {
 							return Expressions.builder()
-									.should(parents(ids))
-									.should(ancestors(ids))
+									.should(addParentsExpressionBasedOnForm(ids))
+									.should(addAncestorsExpressionBasedOnForm(ids))
 									.build();
 						}
+
 					});
 		}
 	}
@@ -199,14 +214,14 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 			return evaluate(context, inner);
 		} else {
 			return evaluate(context, inner)
-					.thenWith(resolveIds(context, inner))
+					.thenWith(resolveIds(context, inner, expressionForm))
 					.then(new Function<Set<String>, Expression>() {
 						@Override
 						public Expression apply(Set<String> ids) {
 							return Expressions.builder()
 									.should(ids(ids))
-									.should(parents(ids))
-									.should(ancestors(ids))
+									.should(addParentsExpressionBasedOnForm(ids))
+									.should(addAncestorsExpressionBasedOnForm(ids))
 									.build();
 						}
 					});
@@ -222,15 +237,15 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 		// <!* should eval to * MINUS parents in (ROOT_ID)
 		if (innerConstraint instanceof Any) {
 			return Promise.immediate(Expressions.builder()
-					.mustNot(parents(Collections.singleton(IComponent.ROOT_ID)))
+					.mustNot(addParentsExpressionBasedOnForm(Collections.singleton(IComponent.ROOT_ID)))
 					.build());
 		} else {
 			return evaluate(context, innerConstraint)
-					.thenWith(resolveIds(context, innerConstraint))
+					.thenWith(resolveIds(context, innerConstraint, expressionForm))
 					.then(new Function<Set<String>, Expression>() {
 						@Override
 						public Expression apply(Set<String> ids) {
-							return parents(ids);
+							return addParentsExpressionBasedOnForm(ids);
 						}
 					});
 		}
@@ -242,14 +257,17 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 */
 	protected Promise<Expression> eval(BranchContext context, final ParentOf parentOf) {
 		final String inner = context.service(EclSerializer.class).serializeWithoutTerms(parentOf.getConstraint());
-		return EclExpression.of(inner)
+		final EclExpression eclExpression = EclExpression.of(inner);
+		eclExpression.setExpressionForm(expressionForm);
+		
+		return eclExpression
 				.resolveConcepts(context)
 				.then(new Function<SnomedConcepts, Set<String>>() {
 					@Override
 					public Set<String> apply(SnomedConcepts concepts) {
 						final Set<String> parents = newHashSet();
 						for (SnomedConcept concept : concepts) {
-							addParentIds(concept, parents);
+							addParentIdsBasedOnForm(concept, parents);
 						}
 						return parents;
 					}
@@ -263,15 +281,17 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 */
 	protected Promise<Expression> eval(BranchContext context, final AncestorOf ancestorOf) {
 		final String inner = context.service(EclSerializer.class).serializeWithoutTerms(ancestorOf.getConstraint());
-		return EclExpression.of(inner)
+		final EclExpression eclExpression = EclExpression.of(inner);
+		eclExpression.setExpressionForm(expressionForm);
+		return eclExpression
 				.resolveConcepts(context)
 				.then(new Function<SnomedConcepts, Set<String>>() {
 					@Override
 					public Set<String> apply(SnomedConcepts concepts) {
 						final Set<String> ancestors = newHashSet();
 						for (SnomedConcept concept : concepts) {
-							addParentIds(concept, ancestors);
-							addAncestorIds(concept, ancestors);
+							addParentIdsBasedOnForm(concept, ancestors);
+							addAncestorIdsBasedOnForm(concept, ancestors);
 						}
 						return ancestors;
 					}
@@ -290,7 +310,9 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 			return evaluate(context, innerConstraint);
 		} else {
 			final String inner = context.service(EclSerializer.class).serializeWithoutTerms(innerConstraint);
-			return EclExpression.of(inner)
+			final EclExpression eclExpression = EclExpression.of(inner);
+			eclExpression.setExpressionForm(expressionForm);
+			return eclExpression
 					.resolveConcepts(context)
 					.then(new Function<SnomedConcepts, Set<String>>() {
 						@Override
@@ -298,8 +320,8 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 							final Set<String> ancestors = newHashSet();
 							for (SnomedConcept concept : concepts) {
 								ancestors.add(concept.getId());
-								addParentIds(concept, ancestors);
-								addAncestorIds(concept, ancestors);
+								addParentIdsBasedOnForm(concept, ancestors);
+								addAncestorIdsBasedOnForm(concept, ancestors);
 							}
 							return ancestors;
 						}
@@ -370,7 +392,9 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 */
 	protected Promise<Expression> eval(final BranchContext context, final RefinedExpressionConstraint refined) {
 		final String focusConceptExpression = context.service(EclSerializer.class).serializeWithoutTerms(refined.getConstraint());
-		return new SnomedEclRefinementEvaluator(EclExpression.of(focusConceptExpression)).evaluate(context, refined.getRefinement());
+		final EclExpression eclExpression = EclExpression.of(focusConceptExpression);
+		eclExpression.setExpressionForm(expressionForm);
+		return new SnomedEclRefinementEvaluator(eclExpression).evaluate(context, refined.getRefinement());
 	}
 	
 	/**
@@ -381,7 +405,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 		final EclSerializer serializer = context.service(EclSerializer.class);
 		final Collection<String> sourceFilter = Collections.singleton(serializer.serializeWithoutTerms(dotted.getConstraint()));
 		final Collection<String> typeFilter = Collections.singleton(serializer.serializeWithoutTerms(dotted.getAttribute()));
-		return SnomedEclRefinementEvaluator.evalRelationships(context, sourceFilter, typeFilter, Collections.emptySet(), false)
+		return SnomedEclRefinementEvaluator.evalRelationships(context, sourceFilter, typeFilter, Collections.emptySet(), false, expressionForm)
 				.then(new Function<Collection<SnomedEclRefinementEvaluator.Property>, Set<String>>() {
 					@Override
 					public Set<String> apply(Collection<SnomedEclRefinementEvaluator.Property> input) {
@@ -429,7 +453,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 * Otherwise it will try to evaluate the ecl completely without using the first returned expression.
 	 * @param ecl - the original ECL which will resolve to the returned function parameter as {@link Expression}
 	 */
-	private static Function<Expression, Promise<Set<String>>> resolveIds(BranchContext context, ExpressionConstraint ecl) {
+	private static Function<Expression, Promise<Set<String>>> resolveIds(BranchContext context, ExpressionConstraint ecl, String expressionForm) {
 		return new Function<Expression, Promise<Set<String>>>() {
 			@Override
 			public Promise<Set<String>> apply(Expression expression) {
@@ -438,30 +462,60 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 				} catch (UnsupportedOperationException e) {
 					final String eclExpression = context.service(EclSerializer.class).serializeWithoutTerms(ecl);
 					// otherwise always evaluate the expression to ID set and return that
-					return EclExpression.of(eclExpression).resolve(context);
+					final EclExpression expressionWithForm = EclExpression.of(eclExpression);
+					expressionWithForm.setExpressionForm(expressionForm);
+					return expressionWithForm.resolve(context);
 				}
 			}
 		};
 	}
 	
-	private static void addParentIds(SnomedConcept concept, final Set<String> collection) {
-		if (concept.getParentIds() != null) {
-			for (long parent : concept.getParentIds()) {
-				if (IComponent.ROOT_IDL != parent) {
-					collection.add(Long.toString(parent));
+	private void addParentIdsBasedOnForm(SnomedConcept concept, final Set<String> collection) {
+		if (Trees.INFERRED_FORM.equals(expressionForm)) {
+			if (concept.getParentIds() != null) {
+				for (long parent : concept.getParentIds()) {
+					if (IComponent.ROOT_IDL != parent) {
+						collection.add(Long.toString(parent));
+					}
+				}
+			}
+		} else {
+			if (concept.getStatedParentIds() != null) {
+				for (long statedParent : concept.getStatedParentIds()) {
+					if (IComponent.ROOT_IDL != statedParent) {
+						collection.add(Long.toString(statedParent));
+					}
 				}
 			}
 		}
 	}
 	
-	private static void addAncestorIds(SnomedConcept concept, Set<String> collection) {
-		if (concept.getAncestorIds() != null) {
-			for (long ancestor : concept.getAncestorIds()) {
-				if (IComponent.ROOT_IDL != ancestor) {
-					collection.add(Long.toString(ancestor));
+	private Expression addParentsExpressionBasedOnForm (Set<String> ids) {
+		return Trees.INFERRED_FORM.equals(expressionForm) ? parents(ids) : statedParents(ids);
+	}
+	
+	private Expression addAncestorsExpressionBasedOnForm(Set<String> ids) {
+		return Trees.INFERRED_FORM.equals(expressionForm) ? ancestors(ids) : statedAncestors(ids);
+	}
+	
+	private void addAncestorIdsBasedOnForm(SnomedConcept concept, final Set<String> collection) {
+		if (Trees.INFERRED_FORM.equals(expressionForm)) {
+			if (concept.getAncestorIds() != null) {
+				for (long ancestor : concept.getAncestorIds()) {
+					if (IComponent.ROOT_IDL != ancestor) {
+						collection.add(Long.toString(ancestor));
+					}
 				}
 			}
-		}		
+		} else {
+			if (concept.getStatedAncestorIds() != null) {
+				for (long statedAncestor : concept.getStatedAncestorIds()) {
+					if (IComponent.ROOT_IDL != statedAncestor) {
+						collection.add(Long.toString(statedAncestor));
+					}
+				}
+			}
+		}
 	}
 	
 	/*package*/ static Function<Set<String>, Expression> matchIdsOrNone() {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
@@ -185,7 +185,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 		// <* should eval to * MINUS parents IN (ROOT_ID)
 		if (inner instanceof Any) {
 			return Promise.immediate(Expressions.builder()
-					.mustNot(addParentsExpressionBasedOnForm(Collections.singleton(IComponent.ROOT_ID)))
+					.mustNot(matchParents(Collections.singleton(IComponent.ROOT_ID)))
 					.build());
 		} else {
 			return evaluate(context, inner)
@@ -194,8 +194,8 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 						@Override
 						public Expression apply(Set<String> ids) {
 							return Expressions.builder()
-									.should(addParentsExpressionBasedOnForm(ids))
-									.should(addAncestorsExpressionBasedOnForm(ids))
+									.should(matchParents(ids))
+									.should(matchAncestors(ids))
 									.build();
 						}
 
@@ -220,8 +220,8 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 						public Expression apply(Set<String> ids) {
 							return Expressions.builder()
 									.should(ids(ids))
-									.should(addParentsExpressionBasedOnForm(ids))
-									.should(addAncestorsExpressionBasedOnForm(ids))
+									.should(matchParents(ids))
+									.should(matchAncestors(ids))
 									.build();
 						}
 					});
@@ -237,7 +237,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 		// <!* should eval to * MINUS parents in (ROOT_ID)
 		if (innerConstraint instanceof Any) {
 			return Promise.immediate(Expressions.builder()
-					.mustNot(addParentsExpressionBasedOnForm(Collections.singleton(IComponent.ROOT_ID)))
+					.mustNot(matchParents(Collections.singleton(IComponent.ROOT_ID)))
 					.build());
 		} else {
 			return evaluate(context, innerConstraint)
@@ -245,7 +245,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 					.then(new Function<Set<String>, Expression>() {
 						@Override
 						public Expression apply(Set<String> ids) {
-							return addParentsExpressionBasedOnForm(ids);
+							return matchParents(ids);
 						}
 					});
 		}
@@ -490,11 +490,11 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 		}
 	}
 	
-	private Expression addParentsExpressionBasedOnForm (Set<String> ids) {
+	private Expression matchParents(Set<String> ids) {
 		return Trees.INFERRED_FORM.equals(expressionForm) ? parents(ids) : statedParents(ids);
 	}
 	
-	private Expression addAncestorsExpressionBasedOnForm(Set<String> ids) {
+	private Expression matchAncestors(Set<String> ids) {
 		return Trees.INFERRED_FORM.equals(expressionForm) ? ancestors(ids) : statedAncestors(ids);
 	}
 	

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestBuilder.java
@@ -21,6 +21,8 @@ import com.b2international.snowowl.core.events.BaseRequestBuilder;
 import com.b2international.snowowl.core.events.Request;
 import com.b2international.snowowl.core.events.util.Promise;
 import com.b2international.snowowl.datastore.request.RevisionIndexRequestBuilder;
+import com.b2international.snowowl.snomed.core.tree.Trees;
+import com.google.common.base.Preconditions;
 
 /**
  * @since 5.4
@@ -28,16 +30,28 @@ import com.b2international.snowowl.datastore.request.RevisionIndexRequestBuilder
 public final class SnomedEclEvaluationRequestBuilder 
 		extends BaseRequestBuilder<SnomedEclEvaluationRequestBuilder, BranchContext, Promise<Expression>> 
 		implements RevisionIndexRequestBuilder<Promise<Expression>> {
-
-	private final SnomedEclEvaluationRequest req = new SnomedEclEvaluationRequest();
+	
+	private String expression;
+	
+	private String expressionForm = Trees.INFERRED_FORM;
 	
 	public SnomedEclEvaluationRequestBuilder(String expression) {
-		req.setExpression(expression);
+		this.expression = expression;
+	}
+
+	public SnomedEclEvaluationRequestBuilder setExpressionForm(String expressionForm) {
+		Preconditions.checkArgument(Trees.INFERRED_FORM.equals(expressionForm) || Trees.STATED_FORM.equals(expressionForm));
+		this.expressionForm = expressionForm;
+		return getSelf();
 	}
 	
 	@Override
 	protected Request<BranchContext, Promise<Expression>> doBuild() {
-		return req;
+		final SnomedEclEvaluationRequest request = new SnomedEclEvaluationRequest();
+		
+		request.setExpression(expression);
+		request.setExpressionForm(expressionForm);
+		return request;
 	}
 	
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestBuilder.java
@@ -31,7 +31,7 @@ public final class SnomedEclEvaluationRequestBuilder
 		extends BaseRequestBuilder<SnomedEclEvaluationRequestBuilder, BranchContext, Promise<Expression>> 
 		implements RevisionIndexRequestBuilder<Promise<Expression>> {
 	
-	private String expression;
+	private final String expression;
 	
 	private String expressionForm = Trees.INFERRED_FORM;
 	
@@ -40,7 +40,7 @@ public final class SnomedEclEvaluationRequestBuilder
 	}
 
 	public SnomedEclEvaluationRequestBuilder setExpressionForm(String expressionForm) {
-		Preconditions.checkArgument(Trees.INFERRED_FORM.equals(expressionForm) || Trees.STATED_FORM.equals(expressionForm));
+		Preconditions.checkArgument(Trees.INFERRED_FORM.equals(expressionForm) || Trees.STATED_FORM.equals(expressionForm), String.format("Expression form must be either %s or %s but got %s", Trees.INFERRED_FORM, Trees.STATED_FORM, expressionForm));
 		this.expressionForm = expressionForm;
 		return getSelf();
 	}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
@@ -106,8 +106,11 @@ final class SnomedEclRefinementEvaluator {
 	
 	private final EclExpression focusConcepts;
 	
+	private String expressionForm = Trees.INFERRED_FORM;
+	
 	public SnomedEclRefinementEvaluator(EclExpression focusConcepts) {
 		this.focusConcepts = focusConcepts;
+		this.expressionForm = focusConcepts.getExpressionForm();
 	}
 	
 	public Promise<Expression> evaluate(BranchContext context, Refinement refinement) {
@@ -423,7 +426,7 @@ final class SnomedEclRefinementEvaluator {
 			final Collection<String> destinationConceptFilter = Collections.singleton(serializer.serializeWithoutTerms(((AttributeComparison) comparison).getConstraint()));
 			final Collection<String> focusConceptFilter = refinement.isReversed() ? destinationConceptFilter : null;
 			final Collection<String> valueConceptFilter = refinement.isReversed() ? null : destinationConceptFilter;
-			return evalRelationships(context, focusConceptFilter, typeConceptFilter, valueConceptFilter, grouped, focusConcepts.getExpressionForm());
+			return evalRelationships(context, focusConceptFilter, typeConceptFilter, valueConceptFilter, grouped, expressionForm);
 		} else if (comparison instanceof DataTypeComparison) {
 			if (grouped) {
 				throw new BadRequestException("Group refinement is not supported in data type based comparison (string/numeric)");
@@ -500,7 +503,7 @@ final class SnomedEclRefinementEvaluator {
 		} else {
 			return SnomedEclEvaluationRequest.throwUnsupported(comparison);
 		}
-		return evalMembers(context, attributeNames, type, value, operator, focusConcepts.getExpressionForm())
+		return evalMembers(context, attributeNames, type, value, operator)
 				.then(new Function<SnomedReferenceSetMembers, Collection<Property>>() {
 					@Override
 					public Collection<Property> apply(SnomedReferenceSetMembers matchingMembers) {
@@ -523,8 +526,7 @@ final class SnomedEclRefinementEvaluator {
 			final Collection<String> attributeNames, 
 			final DataType type, 
 			final Object value, 
-			SearchResourceRequest.Operator operator,
-			String expressionForm) {
+			SearchResourceRequest.Operator operator) {
 		final Set<String> characteristicTypes = Trees.INFERRED_FORM.equals(expressionForm) 
 					? INFERRED_CHARACTERISTIC_TYPES
 					: STATED_CHARACTERISTIC_TYPES;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequest.java
@@ -45,6 +45,7 @@ import com.b2international.snowowl.snomed.core.domain.Acceptability;
 import com.b2international.snowowl.snomed.core.domain.SnomedConcepts;
 import com.b2international.snowowl.snomed.core.domain.SnomedDescription;
 import com.b2international.snowowl.snomed.core.ecl.EclExpression;
+import com.b2international.snowowl.snomed.core.tree.Trees;
 import com.b2international.snowowl.snomed.datastore.converter.SnomedConverters;
 import com.b2international.snowowl.snomed.datastore.escg.ConceptIdQueryEvaluator2;
 import com.b2international.snowowl.snomed.datastore.escg.EscgParseFailedException;
@@ -92,9 +93,14 @@ final class SnomedConceptSearchRequest extends SnomedComponentSearchRequest<Snom
 		ESCG,
 		
 		/**
-		 * ECL expression to match
+		 * ECL expression to match in the inferred tree
 		 */
 		ECL,
+		
+		/**
+		 * ECL expression to match in the stated tree
+		 */
+		STATED_ECL,
 		
 		/**
 		 * The definition status to match
@@ -206,6 +212,15 @@ final class SnomedConceptSearchRequest extends SnomedComponentSearchRequest<Snom
 			// thus the need for allowing this request to time out to avoid deadlock. 
 			// set to 1 minute to match tomcat's time out
 			queryBuilder.filter(EclExpression.of(ecl).resolveToExpression(context).getSync(1, TimeUnit.MINUTES));
+		}
+		
+		if (containsKey(OptionKey.STATED_ECL)) {
+			final String statedEcl = getString(OptionKey.STATED_ECL);
+			
+			final EclExpression expression = EclExpression.of(statedEcl);
+			expression.setExpressionForm(Trees.STATED_FORM);
+			
+			queryBuilder.filter(expression.resolveToExpression(context).getSync(1, TimeUnit.MINUTES));
 		}
 		
 		Expression searchProfileQuery = null;

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequestBuilder.java
@@ -107,8 +107,8 @@ public final class SnomedConceptSearchRequestBuilder extends SnomedComponentSear
 	}
 
 	/**
-	 * Filter matches by the specified Expression Constraint Language (ECL) expression. 
-	 * The currently supported ECL version is v1.1. See <a href="http://snomed.org/ecl">ECL Specification and Guide</a> or
+	 * Filter matches in the inferred tree by the specified Expression Constraint Language (ECL) expression. 
+	 * The currently supported ECL version is v1.3. See <a href="http://snomed.org/ecl">ECL Specification and Guide</a> or
 	 * <a href="http://www.snomed.org/news-articles/expression-constraint-language">About ECL</a> for more information.
 	 * 
 	 * @param expression ECL expression
@@ -116,6 +116,18 @@ public final class SnomedConceptSearchRequestBuilder extends SnomedComponentSear
 	 */
 	public final SnomedConceptSearchRequestBuilder filterByEcl(String expression) {
 		return addOption(SnomedConceptSearchRequest.OptionKey.ECL, expression);
+	}
+	
+	/**
+	 * Filter matches in the stated tree by the specified Expression Constraint Language (ECL) expression. 
+	 * The currently supported ECL version is v1.3. See <a href="http://snomed.org/ecl">ECL Specification and Guide</a> or
+	 * <a href="http://www.snomed.org/news-articles/expression-constraint-language">About ECL</a> for more information.
+	 * 
+	 * @param expression ECL expression
+	 * @return SnomedConceptSearchRequestBuilder
+	 */
+	public final SnomedConceptSearchRequestBuilder filterByStatedEcl(String expression) {
+		return addOption(SnomedConceptSearchRequest.OptionKey.STATED_ECL, expression);
 	}
 
 	/**


### PR DESCRIPTION
This pull request adds support for ECL evaluation in the stated tree.
I've made a mistake and did a typo in the commit issue number.
The original ticket for the issue is MAINT-113(link below)
https://jira.ihtsdotools.org/browse/MAINT-113