### PR TITLE
MAINT-245: Allow concept create requests for bulk endpoint

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/domain/browser/SnomedBrowserBulkChangeRun.java
+++ b/snomed/com.b2international.snowowl.snomed.api.impl/src/com/b2international/snowowl/snomed/api/impl/domain/browser/SnomedBrowserBulkChangeRun.java
@@ -1,9 +1,11 @@
 package com.b2international.snowowl.snomed.api.impl.domain.browser;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import com.b2international.snowowl.snomed.api.domain.browser.ISnomedBrowserBulkChangeRun;
+import com.b2international.snowowl.snomed.api.domain.browser.ISnomedBrowserConcept;
 import com.b2international.snowowl.snomed.api.domain.browser.SnomedBrowserBulkChangeStatus;
 
 public class SnomedBrowserBulkChangeRun implements ISnomedBrowserBulkChangeRun {
@@ -12,6 +14,8 @@ public class SnomedBrowserBulkChangeRun implements ISnomedBrowserBulkChangeRun {
 	private Date startDate;
 	private Date endDate;
 	private SnomedBrowserBulkChangeStatus status;
+	private List<String> conceptIds;
+	private List<ISnomedBrowserConcept> concepts;
 
 	public SnomedBrowserBulkChangeRun() {
 		this.id = UUID.randomUUID().toString();
@@ -27,10 +31,12 @@ public class SnomedBrowserBulkChangeRun implements ISnomedBrowserBulkChangeRun {
 		this.endDate = new Date();
 	}
 	
+	@Override
 	public String getId() {
 		return id;
 	}
 	
+	@Override
 	public SnomedBrowserBulkChangeStatus getStatus() {
 		return status;
 	}
@@ -45,5 +51,23 @@ public class SnomedBrowserBulkChangeRun implements ISnomedBrowserBulkChangeRun {
 	
 	public Date getEndDate() {
 		return endDate;
+	}
+
+	@Override
+	public List<ISnomedBrowserConcept> getConcepts() {
+		return concepts;
+	}
+
+	public void setConcepts(List<ISnomedBrowserConcept> concepts) {
+		this.concepts = concepts;
+	}
+
+	@Override
+	public List<String> getConceptIds() {
+		return conceptIds;
+	}
+
+	public void setConceptIds(List<String> conceptIds) {
+		this.conceptIds = conceptIds;
 	}
 }

--- a/snomed/com.b2international.snowowl.snomed.api/src/com/b2international/snowowl/snomed/api/browser/ISnomedBrowserService.java
+++ b/snomed/com.b2international.snowowl.snomed.api/src/com/b2international/snowowl/snomed/api/browser/ISnomedBrowserService.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.b2international.commons.http.ExtendedLocale;
+import com.b2international.commons.options.Options;
 import com.b2international.snowowl.core.domain.IComponentRef;
 import com.b2international.snowowl.core.domain.IStorageRef;
 import com.b2international.snowowl.core.domain.exceptions.CodeSystemNotFoundException;
@@ -125,8 +126,8 @@ public interface ISnomedBrowserService {
 
 	void update(String branch, List<? extends ISnomedBrowserConcept> concept, String userId, List<ExtendedLocale> extendedLocales);
 	
-	ISnomedBrowserBulkChangeRun beginBulkChange(String branch, List<? extends ISnomedBrowserConcept> newVersionConcepts, String userId, List<ExtendedLocale> locales);
+	ISnomedBrowserBulkChangeRun beginBulkChange(String branch, List<? extends ISnomedBrowserConcept> newVersionConcepts, Boolean allowCreate, String userId, List<ExtendedLocale> locales);
 
-	ISnomedBrowserBulkChangeRun getBulkChange(String bulkChangeId);
+	ISnomedBrowserBulkChangeRun getBulkChange(String branch, String bulkChangeId, List<ExtendedLocale> locales, Options expand);
 
 }

--- a/snomed/com.b2international.snowowl.snomed.api/src/com/b2international/snowowl/snomed/api/domain/browser/ISnomedBrowserBulkChangeRun.java
+++ b/snomed/com.b2international.snowowl.snomed.api/src/com/b2international/snowowl/snomed/api/domain/browser/ISnomedBrowserBulkChangeRun.java
@@ -1,8 +1,25 @@
 package com.b2international.snowowl.snomed.api.domain.browser;
 
+import java.util.List;
+
 public interface ISnomedBrowserBulkChangeRun {
 
 	String getId();
+
 	SnomedBrowserBulkChangeStatus getStatus();
-	
+
+	/**
+	 * Returns all the concept ids affected by the bulk change (either create or update requests)
+	 * 
+	 * @return a list of concept ids
+	 */
+	List<String> getConceptIds();
+
+	/**
+	 * If concepts() expand parameter is used, all affected concepts are expanded and returned through this method as {@link ISnomedBrowserConcept}s
+	 * 
+	 * @return
+	 */
+	List<ISnomedBrowserConcept> getConcepts();
+
 }


### PR DESCRIPTION
- POST /browser/{path}/concepts/bulk
  - from now on the endpoint accepts a flag (allowCreate, default value
is false) which allows concept create requests to be processed during
bulk requests.
  - this is a **non-breaking** change
- GET /browser/{path}/concepts/bulk/{bulkChangeId}
  - from now on the response will contain all affected concept ids (let
it be an update or a create requests) in the same order they were
present in the original bulk request
  - if required all concepts can be expanded when the expand parameter
'concepts()' is specified.
  - upon concept expansion language settings can be specified as well
  - this is a **non-breaking** change
- added unit tests to verify the above changes

https://jira.ihtsdotools.org/browse/MAINT-245