### PR TITLE
MAINT-494: Fix stated ECL evaluation

### DIFF
--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequestTest.java
@@ -1217,13 +1217,13 @@ public class SnomedEclEvaluationRequestTest extends BaseRevisionIndexTest {
 	 */
 	private void generateHierarchy() {
 		// substances
-		indexRevision(MAIN, nextStorageKey(), concept(INGREDIENT1).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(SUBSTANCE))).build());
-		indexRevision(MAIN, nextStorageKey(), concept(INGREDIENT2).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(SUBSTANCE))).build());
+		indexRevision(MAIN, nextStorageKey(), concept(INGREDIENT1).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(SUBSTANCE))).statedParents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(SUBSTANCE))).build());
+		indexRevision(MAIN, nextStorageKey(), concept(INGREDIENT2).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(SUBSTANCE))).statedParents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(SUBSTANCE))).build());
 		
 		//drugs
-		indexRevision(MAIN, nextStorageKey(), concept(ABACAVIR_TABLET).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).build());
-		indexRevision(MAIN, nextStorageKey(), concept(PANADOL_TABLET).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).build());
-		indexRevision(MAIN, nextStorageKey(), concept(TRIPHASIL_TABLET).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).build());
+		indexRevision(MAIN, nextStorageKey(), concept(ABACAVIR_TABLET).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).statedParents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).build());
+		indexRevision(MAIN, nextStorageKey(), concept(PANADOL_TABLET).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).statedParents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).build());
+		indexRevision(MAIN, nextStorageKey(), concept(TRIPHASIL_TABLET).parents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).statedParents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(DRUG_ROOT))).build());
 		
 		indexRevision(MAIN, nextStorageKey(), relationship(PANADOL_TABLET, HAS_ACTIVE_INGREDIENT, INGREDIENT1).group(1).build());
 		indexRevision(MAIN, nextStorageKey(), relationship(PANADOL_TABLET, HAS_BOSS, INGREDIENT2).group(1).build());

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedStatedEclEvaluationTest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/core/ecl/SnomedStatedEclEvaluationTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2018 B2i Healthcare Pte Ltd, http://b2i.sg
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.b2international.snowowl.snomed.core.ecl;
+
+import static com.b2international.snowowl.datastore.index.RevisionDocument.Expressions.ids;
+import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedAncestors;
+import static com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument.Expressions.statedParents;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.xtext.parser.IParser;
+import org.eclipse.xtext.serializer.ISerializer;
+import org.eclipse.xtext.validation.IResourceValidator;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.b2international.collections.PrimitiveCollectionModule;
+import com.b2international.collections.PrimitiveSets;
+import com.b2international.index.Index;
+import com.b2international.index.query.Expression;
+import com.b2international.index.query.Expressions;
+import com.b2international.index.revision.BaseRevisionIndexTest;
+import com.b2international.index.revision.RevisionIndex;
+import com.b2international.snowowl.core.date.EffectiveTimes;
+import com.b2international.snowowl.core.domain.BranchContext;
+import com.b2international.snowowl.core.domain.IComponent;
+import com.b2international.snowowl.datastore.request.RevisionIndexReadRequest;
+import com.b2international.snowowl.snomed.SnomedConstants.Concepts;
+import com.b2international.snowowl.snomed.core.tree.Trees;
+import com.b2international.snowowl.snomed.datastore.id.RandomSnomedIdentiferGenerator;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedConceptDocument;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedDescriptionIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRefSetMemberIndexEntry;
+import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationshipIndexEntry;
+import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
+import com.b2international.snowowl.snomed.ecl.EclStandaloneSetup;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+
+/**
+ * @since 5.15.1
+ */
+public class SnomedStatedEclEvaluationTest extends BaseRevisionIndexTest {
+	
+	private static final String ROOT_CONCEPT = RandomSnomedIdentiferGenerator.generateConceptId();
+	private static final String HAS_ACTIVE_INGREDIENT = Concepts.HAS_ACTIVE_INGREDIENT;
+	private static final String SUBSTANCE = Concepts.SUBSTANCE;
+	private static final String STATED_CONCEPT = RandomSnomedIdentiferGenerator.generateConceptId();
+
+	private BranchContext context;
+	
+	@Before
+	public void setup() {
+		super.setup();
+		final Injector injector = new EclStandaloneSetup().createInjectorAndDoEMFRegistration();
+		context = TestBranchContext.on(MAIN)
+				.with(EclParser.class, new DefaultEclParser(injector.getInstance(IParser.class), injector.getInstance(IResourceValidator.class)))
+				.with(EclSerializer.class, new DefaultEclSerializer(injector.getInstance(ISerializer.class)))
+				.with(Index.class, rawIndex())
+				.with(RevisionIndex.class, index())
+				.build();
+	}
+	
+	@Override
+	protected void configureMapper(ObjectMapper mapper) {
+		super.configureMapper(mapper);
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		mapper.registerModule(new PrimitiveCollectionModule());
+	}
+	
+	@Override
+	protected Collection<Class<?>> getTypes() {
+		return ImmutableSet.of(SnomedDescriptionIndexEntry.class, SnomedConceptDocument.class, SnomedRelationshipIndexEntry.class, SnomedRefSetMemberIndexEntry.class);
+	}
+	
+	@Test
+	public void statedRefinementWithZeroToOneCardinalityInAttributeConjuction() throws Exception {
+		generateTestHierarchy();
+		final Expression actual = eval(String.format("<<%s:[1..*]{[0..1]%s=<<%s}", ROOT_CONCEPT, HAS_ACTIVE_INGREDIENT, SUBSTANCE));
+		
+		final Expression expected = and(
+				descendantsOrSelfOf(ROOT_CONCEPT),
+				ids(ImmutableSet.of(STATED_CONCEPT))
+				);
+		assertEquals(expected, actual);
+	}
+	
+	private Expression eval(String expression) {
+		return new RevisionIndexReadRequest<>(SnomedRequests.prepareEclEvaluation(expression).setExpressionForm(Trees.STATED_FORM).build())
+				.execute(context)
+				.getSync();		
+	}
+	
+	private void generateTestHierarchy() {
+		indexRevision(MAIN, nextStorageKey(), concept(STATED_CONCEPT).statedParents(PrimitiveSets.newLongOpenHashSet(Long.parseLong(ROOT_CONCEPT))).build());
+		
+		indexRevision(MAIN, nextStorageKey(), relationship(STATED_CONCEPT, HAS_ACTIVE_INGREDIENT, SUBSTANCE).group(1).build());
+	}
+	
+	private SnomedConceptDocument.Builder concept(final String id) {
+		return SnomedConceptDocument.builder()
+				.id(id)
+				.iconId(Concepts.ROOT_CONCEPT)
+				.active(true)
+				.released(true)
+				.exhaustive(false)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.effectiveTime(EffectiveTimes.UNSET_EFFECTIVE_TIME)
+				.primitive(true)
+				.parents(PrimitiveSets.newLongOpenHashSet(IComponent.ROOT_IDL))
+				.ancestors(PrimitiveSets.newLongOpenHashSet(IComponent.ROOT_IDL))
+				.statedParents(PrimitiveSets.newLongOpenHashSet(IComponent.ROOT_IDL))
+				.statedAncestors(PrimitiveSets.newLongOpenHashSet(IComponent.ROOT_IDL))
+				.referringRefSets(Collections.<String>emptySet())
+				.referringMappingRefSets(Collections.<String>emptySet());
+	}
+	
+	private SnomedRelationshipIndexEntry.Builder relationship(final String source, final String type, final String destination) {
+		return SnomedRelationshipIndexEntry.builder()
+				.id(RandomSnomedIdentiferGenerator.generateRelationshipId())
+				.active(true)
+				.moduleId(Concepts.MODULE_SCT_CORE)
+				.sourceId(source)
+				.typeId(type)
+				.destinationId(destination)
+				.characteristicTypeId(Concepts.STATED_RELATIONSHIP)
+				.modifierId(Concepts.EXISTENTIAL_RESTRICTION_MODIFIER);
+	}
+	
+	private Expression descendantsOrSelfOf(String...conceptIds) {
+		return Expressions.builder()
+				.should(ids(ImmutableSet.copyOf(conceptIds)))
+				.should(statedParents(ImmutableSet.copyOf(conceptIds)))
+				.should(statedAncestors(ImmutableSet.copyOf(conceptIds))).build();
+	}
+	
+	private static Expression and(Expression left, Expression right) {
+		return Expressions.builder().filter(left).filter(right).build();
+	}
+
+}

--- a/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore.tests/src/com/b2international/snowowl/snomed/datastore/AllSnomedDatastoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.b2international.snowowl.snomed.core.ecl.SnomedEclEvaluationRequestTest;
 import com.b2international.snowowl.snomed.core.ecl.SnomedEclRewriterTest;
+import com.b2international.snowowl.snomed.core.ecl.SnomedStatedEclEvaluationTest;
 import com.b2international.snowowl.snomed.core.tree.TerminologyTreeTest;
 import com.b2international.snowowl.snomed.datastore.id.memory.DefaultSnomedIdentifierServiceRegressionTest;
 import com.b2international.snowowl.snomed.datastore.id.memory.DefaultSnomedIdentifierServiceTest;
@@ -61,6 +62,7 @@ import com.b2international.snowowl.snomed.datastore.internal.id.reservations.Sno
 	ConstraintChangeProcessorTest.class,
 	ConceptChangeProcessorTest.class,
 	SnomedEclEvaluationRequestTest.class,
+	SnomedStatedEclEvaluationTest.class,
 	SnomedEclRewriterTest.class
 })
 public class AllSnomedDatastoreTests {

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/EclExpression.java
@@ -39,6 +39,7 @@ import com.b2international.snowowl.snomed.datastore.index.entry.SnomedRelationsh
 import com.b2international.snowowl.snomed.datastore.request.SnomedRequests;
 import com.b2international.snowowl.snomed.ecl.Ecl;
 import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -49,28 +50,33 @@ import com.google.common.collect.Multimaps;
 public final class EclExpression {
 
 	private final String ecl;
-	
-	private String expressionForm = Trees.INFERRED_FORM;
+	private final String expressionForm;
 	
 	private Promise<Set<String>> promise;
 	private Promise<Expression> expressionPromise;
 	private Promise<SnomedConcepts> conceptPromise;
 	private Promise<Multimap<String, Integer>> conceptsWithGroups;
 
-	private EclExpression(String ecl) {
+	private EclExpression(String ecl, String expressionForm) {
 		this.ecl = ecl.trim();
+		this.expressionForm = expressionForm;
+		Preconditions.checkArgument(isInferred() || isStated(), "Allowed expression forms are 'inferred', 'stated' but was '%s'", expressionForm);
 	}
 	
 	public String getEcl() {
 		return ecl;
 	}
 	
-	public void setExpressionForm(String expressionForm) {
-		this.expressionForm = expressionForm;
-	}
-	
 	public String getExpressionForm() {
 		return expressionForm;
+	}
+	
+	public boolean isInferred() {
+		return Trees.INFERRED_FORM.equals(expressionForm);
+	}
+	
+	public boolean isStated() {
+		return Trees.STATED_FORM.equals(expressionForm);
 	}
 	
 	public boolean isAnyExpression() {
@@ -118,8 +124,8 @@ public final class EclExpression {
 		return expressionPromise;
 	}
 	
-	public static EclExpression of(String ecl) {
-		return new EclExpression(ecl);
+	public static EclExpression of(String ecl, String expressionForm) {
+		return new EclExpression(ecl, expressionForm);
 	}
 	
 	public Promise<Expression> resolveToExclusionExpression(final BranchContext context, final Set<String> excludedMatches) {
@@ -138,7 +144,7 @@ public final class EclExpression {
 	
 	public Promise<Multimap<String, Integer>> resolveToConceptsWithGroups(final BranchContext context) {
 		if (conceptsWithGroups == null) {
-			final Set<String> characteristicTypes = Trees.INFERRED_FORM.equals(expressionForm)
+			final Set<String> characteristicTypes = isInferred()
 					? SnomedEclRefinementEvaluator.INFERRED_CHARACTERISTIC_TYPES
 					: SnomedEclRefinementEvaluator.STATED_CHARACTERISTIC_TYPES;
 			conceptsWithGroups = SnomedRequests.prepareSearchRelationship()
@@ -147,6 +153,7 @@ public final class EclExpression {
 					.filterByCharacteristicTypes(characteristicTypes)
 					.filterBySource(ecl)
 					.filterByGroup(1, Integer.MAX_VALUE)
+					.setEclExpressionForm(expressionForm)
 					.setFields(SnomedRelationshipIndexEntry.Fields.ID, SnomedRelationshipIndexEntry.Fields.SOURCE_ID, SnomedRelationshipIndexEntry.Fields.GROUP)
 					.build(context.id(), context.branchPath())
 					.execute(context.service(IEventBus.class))
@@ -179,5 +186,5 @@ public final class EclExpression {
 					});
 		}
 	}
-	
+
 }

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclEvaluationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,9 +161,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 					.build());
 		} else if (inner instanceof NestedExpression) {
 			final String focusConceptExpression = context.service(EclSerializer.class).serializeWithoutTerms(inner);
-			final EclExpression eclExpression = EclExpression.of(focusConceptExpression);
-			eclExpression.setExpressionForm(expressionForm);
-			return eclExpression
+			return EclExpression.of(focusConceptExpression, expressionForm)
 					.resolve(context)
 					.then(ids -> {
 						return Expressions.builder()
@@ -257,10 +255,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 */
 	protected Promise<Expression> eval(BranchContext context, final ParentOf parentOf) {
 		final String inner = context.service(EclSerializer.class).serializeWithoutTerms(parentOf.getConstraint());
-		final EclExpression eclExpression = EclExpression.of(inner);
-		eclExpression.setExpressionForm(expressionForm);
-		
-		return eclExpression
+		return EclExpression.of(inner, expressionForm)
 				.resolveConcepts(context)
 				.then(new Function<SnomedConcepts, Set<String>>() {
 					@Override
@@ -281,8 +276,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 */
 	protected Promise<Expression> eval(BranchContext context, final AncestorOf ancestorOf) {
 		final String inner = context.service(EclSerializer.class).serializeWithoutTerms(ancestorOf.getConstraint());
-		final EclExpression eclExpression = EclExpression.of(inner);
-		eclExpression.setExpressionForm(expressionForm);
+		final EclExpression eclExpression = EclExpression.of(inner, expressionForm);
 		return eclExpression
 				.resolveConcepts(context)
 				.then(new Function<SnomedConcepts, Set<String>>() {
@@ -310,9 +304,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 			return evaluate(context, innerConstraint);
 		} else {
 			final String inner = context.service(EclSerializer.class).serializeWithoutTerms(innerConstraint);
-			final EclExpression eclExpression = EclExpression.of(inner);
-			eclExpression.setExpressionForm(expressionForm);
-			return eclExpression
+			return EclExpression.of(inner, expressionForm)
 					.resolveConcepts(context)
 					.then(new Function<SnomedConcepts, Set<String>>() {
 						@Override
@@ -392,8 +384,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 	 */
 	protected Promise<Expression> eval(final BranchContext context, final RefinedExpressionConstraint refined) {
 		final String focusConceptExpression = context.service(EclSerializer.class).serializeWithoutTerms(refined.getConstraint());
-		final EclExpression eclExpression = EclExpression.of(focusConceptExpression);
-		eclExpression.setExpressionForm(expressionForm);
+		final EclExpression eclExpression = EclExpression.of(focusConceptExpression, expressionForm);
 		return new SnomedEclRefinementEvaluator(eclExpression).evaluate(context, refined.getRefinement());
 	}
 	
@@ -461,10 +452,7 @@ final class SnomedEclEvaluationRequest implements Request<BranchContext, Promise
 					return Promise.immediate(extractIds(expression));
 				} catch (UnsupportedOperationException e) {
 					final String eclExpression = context.service(EclSerializer.class).serializeWithoutTerms(ecl);
-					// otherwise always evaluate the expression to ID set and return that
-					final EclExpression expressionWithForm = EclExpression.of(eclExpression);
-					expressionWithForm.setExpressionForm(expressionForm);
-					return expressionWithForm.resolve(context);
+					return EclExpression.of(eclExpression, expressionForm).resolve(context);
 				}
 			}
 		};

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/core/ecl/SnomedEclRefinementEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -258,7 +258,6 @@ final class SnomedEclRefinementEvaluator {
 							if (cardinality != null && cardinality.getMin() == 0 && cardinality.getMax() != UNBOUNDED_CARDINALITY) {
 								// XXX internal evaluation returns negative matches, that should be excluded from the focusConcept set
 								final Function<Property, Object> idProvider = refinement.isReversed() ? Property::getValue : Property::getObjectId;
-							
 								
 								final Set<String> matchingIds = FluentIterable.from(input).transform(idProvider).filter(String.class).toSet();
 								return focusConcepts.resolveToConceptsWithGroups(context)

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequest.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,14 +211,13 @@ final class SnomedConceptSearchRequest extends SnomedComponentSearchRequest<Snom
 			//XXX: ECL evaluation may fire sub requests that may be aimed at an already FULL event bus
 			// thus the need for allowing this request to time out to avoid deadlock. 
 			// set to 1 minute to match tomcat's time out
-			queryBuilder.filter(EclExpression.of(ecl).resolveToExpression(context).getSync(1, TimeUnit.MINUTES));
+			queryBuilder.filter(EclExpression.of(ecl, Trees.INFERRED_FORM).resolveToExpression(context).getSync(1, TimeUnit.MINUTES));
 		}
 		
 		if (containsKey(OptionKey.STATED_ECL)) {
 			final String statedEcl = getString(OptionKey.STATED_ECL);
 			
-			final EclExpression expression = EclExpression.of(statedEcl);
-			expression.setExpressionForm(Trees.STATED_FORM);
+			final EclExpression expression = EclExpression.of(statedEcl, Trees.STATED_FORM);
 			
 			queryBuilder.filter(expression.resolveToExpression(context).getSync(1, TimeUnit.MINUTES));
 		}

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedConceptSearchRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSearchRequestBuilder.java
+++ b/snomed/com.b2international.snowowl.snomed.datastore/src/com/b2international/snowowl/snomed/datastore/request/SnomedSearchRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2017 B2i Healthcare Pte Ltd, http://b2i.sg
+ * Copyright 2011-2018 B2i Healthcare Pte Ltd, http://b2i.sg
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,5 +127,15 @@ public abstract class SnomedSearchRequestBuilder<B extends SnomedSearchRequestBu
 		 * results have been returned.
 		 */
 		return filterByLanguageRefSetIds(DescriptionRequestHelper.getLanguageRefSetIds(locales));
+	}
+	
+	/**
+	 * Set the ECL expression form to evaluate all ECL expressions on this form.
+	 * 
+	 * @param expressionForm
+	 * @return this builder
+	 */
+	public final B setEclExpressionForm(String expressionForm) {
+		return addOption(OptionKey.ECL_EXPRESSION_FORM, expressionForm);
 	}
 }


### PR DESCRIPTION
This pull request adds a consideration regards of every ECL expression that's present in a search request if it should be executed in the stated or inferred form (defaults to inferred)